### PR TITLE
Add a way to download the maildir without using `lei`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +53,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -58,7 +64,7 @@ checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -78,6 +84,21 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cc"
+version = "1.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -142,10 +163,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "directories-next"
@@ -182,6 +218,22 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -223,6 +275,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,10 +302,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -267,15 +348,20 @@ dependencies = [
  "anyhow",
  "clap",
  "directories-next",
+ "flate2",
+ "indoc",
  "maildir",
  "mailparse",
+ "pretty_assertions",
  "regex",
  "serde",
+ "sha1_smol",
  "tempdir",
  "thiserror 2.0.12",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "ureq",
 ]
 
 [[package]]
@@ -321,6 +407,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,10 +438,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -474,6 +585,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +672,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +685,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
@@ -522,6 +703,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -703,6 +890,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a3e9af6113ecd57b8c63d3cd76a385b2e3881365f1f489e54f49801d0c83ea"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf-8",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadf18427d33828c311234884b7ba2afb57143e6e7e69fda7ee883b624661e36"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +948,24 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -741,6 +988,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -823,3 +1079,15 @@ checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,20 @@ categories = ["command-line-utilities", "email"]
 anyhow = "1.0.98"
 clap = { version = "4.5.37", features = ["derive"] }
 directories-next = "2.0.0"
+flate2 = "1.1.1"
 maildir = "0.6.4"
 # maildir uses "^0.14"
 mailparse = "0.14.1"
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
+sha1_smol = "1.0.1"
 tempdir = "0.3.7"
 thiserror = "2.0.12"
 toml = "0.8.22"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+ureq = "3.0.11"
+
+[dev-dependencies]
+indoc = "2.0.6"
+pretty_assertions = "1.4.1"

--- a/src/assort/mod.rs
+++ b/src/assort/mod.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 use tracing::{error, info, trace, warn};
 
 use crate::{
+    BoxPath,
     assort::{
         folder::{Action, Dest, Folder},
         mail::{Mail, Type},
@@ -24,8 +25,11 @@ mod mail;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("While trying to read a mail file from disk: {0}")]
-    MailIO(io::Error),
+    #[error("While trying to read a mail file from disk at {path:?}: {error}")]
+    MailIO {
+        path: Option<BoxPath>,
+        error: io::Error,
+    },
     #[error("while trying to modify the filesystem: {0}")]
     Fs(io::Error),
     #[error("internal error")]
@@ -103,15 +107,23 @@ fn collect_mails(new: Maildir, main: Maildir, cfg: &Config) -> Result<Collected,
             f.maildir
                 .list_new()
                 .chain(f.maildir.list_cur())
-                .map(move |m| (m, i))
+                .map(move |m| (m, i, f))
         })
-        .map(|(m, i)| Ok::<_, Error>((m.map_err(Error::MailIO)?, Type::Folder(i))))
+        .map(|(m, i, f)| {
+            Ok::<_, Error>((
+                m.map_err(|error| Error::MailIO {
+                    path: Some(f.maildir.path().into()),
+                    error,
+                })?,
+                Type::Folder(i),
+            ))
+        })
         .collect::<Result<Vec<_>, _>>()?;
     let mut dupe = Vec::with_capacity(100);
     let mut new_count = 0;
     for mail in newmail.list_cur().chain(newmail.list_new()) {
         new_count += 1;
-        let mut mail = mail.map_err(Error::MailIO)?;
+        let mut mail = mail.map_err(|error| Error::MailIO { path: None, error })?;
         if mail
             .headers()?
             .get_all_values("list-id")
@@ -201,10 +213,16 @@ fn index<'a>(
                 actions.insert(mail.clone(), Action::delete(DropReason::PrefixCopy));
             } else {
                 error!(
-                    "new email received with same id as existing, pls implement!\n{:#?} vs\n{}\n\n {:#?}",
+                    "new email received with same id as existing, pls implement!\n\
+                    {:#?}\n\
+                    vs: `{}`\n\
+                    Message IDs: {msg_ids:?}\n\
+                    List IDs: {list_ids:?}\n\
+                    note: you may need to set `quirks.deduplicate` in your configuration",
                     mails.iter().map(|m| m.path.display()).collect::<Vec<_>>(),
                     mail.path.display(),
-                    mail.parsed.headers.get_all_values("list-id")
+                    msg_ids = mail.parsed.headers.get_all_values("Message-ID"),
+                    list_ids = mail.parsed.headers.get_all_values("list-id"),
                 );
                 error = true
             }
@@ -222,7 +240,7 @@ fn index<'a>(
         if *typ == Type::New {
             new.push(mail.clone());
         }
-        trace!("{}", mail.id);
+        trace!("processed {}", mail.id);
         mails.push(mail);
     }
     if error {
@@ -435,9 +453,9 @@ fn perform<'a>(actions: HashMap<Rc<Mail<'a>>, Action>, folders: &[Folder]) -> Re
         let id = &mail.maildir_id;
         let flags = action.flags();
         let dest = match action.dest() {
-            Dest::Drop(_) => {
+            Dest::Drop(reason) => {
                 std::fs::remove_file(&mail.path).map_err(Error::Fs)?;
-                info!("deleting `{id}`");
+                info!("deleted `{id}` ({reason:?})");
                 continue;
             }
             Dest::Folder(idx) => &folders[idx].maildir,

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,12 @@ pub struct Config {
     /// ```
     pub query: String,
 
+    /// Instead of invoking `lei`, download and expand the mbox directly.
+    ///
+    /// WARNING: this may be less reliable than `lei`.
+    #[serde(default)]
+    pub no_lei: bool,
+
     /// Quirk fixes for mail clients, mailing lists etc.
     #[serde(default)]
     pub quirks: Quirks,

--- a/src/lei.rs
+++ b/src/lei.rs
@@ -1,17 +1,25 @@
-use std::{io, process::Command};
+use std::{io, path::Path, process::Command};
 
 use clap::ValueEnum;
 use tempdir::TempDir;
 use thiserror::Error;
+use tracing::debug;
+
+use crate::lei::leiless::LeiLess;
+mod leiless;
+
+const DEFAULT_INBOX: &str = "https://lore.kernel.org/all/";
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("could not execute `lei`: {0}")]
+    #[error("could not execute `lei`: {0}. Consider using the `no_lei` config option.")]
     Start(#[from] io::Error),
     #[error("`lei` failed execution with error code {0}")]
     Code(i32),
     #[error("`lei` execution unexpectedly terminated by signal.")]
     Signal,
+    #[error("failed to produce mdir from public-inbox: {0}")]
+    NoLei(#[from] leiless::Error),
 }
 
 type Result<T = ()> = core::result::Result<T, Error>;
@@ -28,7 +36,7 @@ pub enum Interval {
     Year,
 }
 
-pub fn query(interval: Interval, query: &str) -> Result<TempDir> {
+pub fn query(interval: Interval, query: &str, no_lei: bool) -> Result<TempDir> {
     let interval = match interval {
         Interval::Day => "2.day.ago",
         Interval::Week => "2.week.ago",
@@ -36,21 +44,58 @@ pub fn query(interval: Interval, query: &str) -> Result<TempDir> {
         Interval::Year => "1.year.ago",
     };
     let tmpdir = TempDir::new("lkml-lei")?;
-    let res = Command::new("lei")
-        .arg("q")
-        .args([
-            // don't store the query, as we're storing it in our config.
-            "--no-save",
-            // get all emails from the thread where a single one has matched.
-            "--threads",
-            "--include=https://lore.kernel.org/all",
-        ])
-        .arg(format!("--output={}", tmpdir.path().display()))
-        .arg(format!("({query}) AND rt:{interval}.."))
-        .status()?;
-    if !res.success() {
-        Err(res.code().map(Error::Code).unwrap_or(Error::Signal))
-    } else {
-        Ok(tmpdir)
+    let q = format!("({query}) AND rt:{interval}..");
+    debug!("query: `{q}`");
+
+    let cfg = PullCfg {
+        inbox: DEFAULT_INBOX,
+        threads: true,
+        query: &q,
+    };
+
+    let lei: &dyn LeiLike = if no_lei { &LeiLess } else { &LeiCli };
+    lei.download(&cfg, tmpdir.path()).map(|()| tmpdir)
+}
+
+#[derive(Debug)]
+pub struct PullCfg<'a> {
+    /// The lore server address.
+    pub inbox: &'a str,
+    /// True to retrieve an entire thread if a middle query is matched.
+    pub threads: bool,
+    /// public-inbox query.
+    pub query: &'a str,
+}
+
+/// Abstraction over CLI `lei` and our implementation.
+trait LeiLike {
+    /// Download  a query to a given directory.
+    fn download(&self, cfg: &PullCfg, dir: &Path) -> Result<()>;
+}
+
+/// `LeiLike` interfaces using the `lei` CLI.
+struct LeiCli;
+
+impl LeiLike for LeiCli {
+    fn download(&self, cfg: &PullCfg, dir: &Path) -> Result<()> {
+        let mut cmd = Command::new("lei");
+        cmd.arg("q")
+            .args([
+                // don't store the query, as we're storing it in our config.
+                "--no-save",
+                // get all emails from the thread where a single one has matched.
+                "--threads",
+                "--include",
+                cfg.inbox,
+            ])
+            .arg(format!("--output={}", dir.display()))
+            .arg(cfg.query);
+        debug!("{cmd:?}");
+        let res = cmd.status()?;
+        if !res.success() {
+            Err(res.code().map(Error::Code).unwrap_or(Error::Signal))
+        } else {
+            Ok(())
+        }
     }
 }

--- a/src/lei/leiless.rs
+++ b/src/lei/leiless.rs
@@ -1,0 +1,358 @@
+use std::{
+    fmt::Display,
+    fs,
+    io::{self, BufRead, BufReader, Write},
+    path::{Path, PathBuf},
+    time::Instant,
+};
+
+use flate2::read::GzDecoder;
+use thiserror::Error;
+use tracing::{debug, info};
+
+use super::PullCfg;
+use crate::{
+    BoxPath, BoxStr,
+    lei::LeiLike,
+    util::{self, ReadCounter},
+};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("could not reach `{inbox}`: {error}")]
+    Http { inbox: BoxStr, error: ureq::Error },
+    #[error("could not create directory `{path}`: {error}")]
+    CreateDirectory { path: BoxPath, error: io::Error },
+    #[error("could not write new mail file `{path}`: {error}")]
+    WriteMailFile { path: BoxPath, error: io::Error },
+    #[error("failed to read from response {error}")]
+    ReadInputStream { error: io::Error },
+}
+
+type Result<T = ()> = core::result::Result<T, Error>;
+
+/// Every N bytes, post an update.
+const MSG_INTERVAL: u64 = 10 * 1024;
+
+const PATH_SEP: char = if cfg!(windows) { ';' } else { ':' };
+
+/// `lei` interfaces using Rust implementations.
+pub struct LeiLess;
+
+impl LeiLike for LeiLess {
+    fn download(&self, cfg: &PullCfg, dir: &Path) -> super::Result<()> {
+        Ok(download_impl(cfg, dir)?)
+    }
+}
+
+fn download_impl(cfg: &PullCfg, dir: &Path) -> Result<()> {
+    // A POST with `?x=m` requests to download messages
+    let mut req = ureq::post(cfg.inbox).query("x", "m");
+    if cfg.threads {
+        req = req.query("t", "1");
+    }
+    req = req.query("q", cfg.query);
+
+    let start = Instant::now();
+    info!("sending request {req:?}");
+    let resp = req.send_empty().map_err(|e| Error::Http {
+        inbox: cfg.inbox.into(),
+        error: e,
+    })?;
+
+    // Lore doesn't seem to set `Content-Length`, but we still try
+    let expected_len: Option<u64> = resp
+        .headers()
+        .get("Content-Length")
+        .and_then(|hval| hval.to_str().ok())
+        .and_then(|hstr| hstr.parse().ok());
+
+    let status = resp.status();
+    if let Some(l) = expected_len {
+        info!("status {status}; receiving {l} bytes",);
+    } else {
+        info!("status {status}; unknown length",);
+    };
+
+    // Wrap the response in a `GzDecoder` so we can decompress on the fly, plus a `BufReader` since
+    // we read individual lines. `ReadCounter`s are inserted so we can separately log how much has
+    // been downloaded and decompressed.
+    let body_reader = BufReader::new(ReadCounter::new(GzDecoder::new(ReadCounter::new(
+        resp.into_body().into_reader(),
+    ))));
+    let cur = create_maildir(dir)?;
+
+    // lei uses the git hash of a message as its filename, plus the maildir `:2,` ending.
+    let create_fname: fn(&[u8]) -> String = |bytes| {
+        let hash = git_hash_object(bytes);
+        format!("{hash}{PATH_SEP}2,")
+    };
+
+    let res = mbox2mdir(
+        body_reader,
+        &cur,
+        create_fname,
+        |r| r.get_ref().get_ref().get_ref().count(),
+        |r| r.get_ref().count(),
+    );
+    let elapsed = Instant::now() - start;
+    println!("Download completed in {elapsed:?}");
+    res
+}
+
+/// Given an input stream that produces `mbox`, split it into individual messages.
+///
+/// Takes callbacks so we can test this without the ureq stream.
+///
+/// Based on <https://github.com/mindbit/mb2md/blob/52d9a9480f521a1e3dda83a0845e6ccfa84e54aa/mb2md.pl>.
+fn mbox2mdir<R: BufRead>(
+    mut r: R,
+    dst: &Path,
+    mut create_fname: impl FnMut(&[u8]) -> String,
+    get_downloaded: impl Fn(&R) -> u64,
+    get_extracted: impl Fn(&R) -> u64,
+) -> Result<()> {
+    let mut buf = Vec::new();
+    let mut current_msg = Vec::with_capacity(1024);
+    let mut total_read = 0u64;
+    let mut messages = 0u64;
+    let mut duplicates = 0u64;
+
+    loop {
+        // Read a single line
+        buf.clear();
+        let read_count = r
+            .read_until(b'\n', &mut buf)
+            .map_err(|error| Error::ReadInputStream { error })?;
+        let line = &buf[..read_count];
+
+        let read_count_u64 = u64::try_from(read_count).unwrap();
+        let new_total_read = total_read + read_count_u64;
+        if new_total_read / MSG_INTERVAL > total_read / MSG_INTERVAL {
+            let downloaded = get_downloaded(&r);
+            let extracted = get_extracted(&r);
+            print!(
+                "\r{downloaded} B downloaded, {extracted} B extracted, {new_total_read} B read, \
+                {messages} messages "
+            );
+        }
+
+        total_read = new_total_read;
+
+        /* This logic is taken from mb2md's `convert` function (not all functionality
+         * is implemented) */
+
+        // Start of a new message or EOF
+        if line.starts_with(b"From ") || read_count == 0 {
+            if !current_msg.is_empty() {
+                // Ensure a single trailing newline
+                current_msg.truncate(current_msg.trim_ascii_end().len());
+                current_msg.push(b'\n');
+                let trimmed = current_msg.trim_ascii_start();
+
+                let fname = create_fname(trimmed);
+                let fpath = dst.join(&fname);
+
+                // Write the file, failing if it exists
+                fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&fpath)
+                    .and_then(|mut f| f.write_all(trimmed))
+                    .or_else(|error| match error.kind() {
+                        // lei deduplicates messages with the same hash automatically
+                        io::ErrorKind::AlreadyExists => {
+                            debug!("duplicate message `{fname}`");
+                            duplicates += 1;
+                            Ok(())
+                        }
+                        _ => Err(error),
+                    })
+                    .map_err(|error| Error::WriteMailFile {
+                        path: fpath.into(),
+                        error,
+                    })?;
+
+                messages += 1;
+                current_msg.clear();
+            }
+
+            if read_count == 0 {
+                // Reached the end of the stream
+                break;
+            }
+
+            continue;
+        }
+
+        // mbox uses `^From ` as the separator and quotes it as `^> From`. Account for this
+        // without allocating an intermediate.
+        match line.strip_prefix(b"> From ") {
+            Some(stripped) => {
+                current_msg.extend_from_slice(b"From ");
+                current_msg.extend_from_slice(stripped);
+            }
+            None => current_msg.extend_from_slice(line),
+        }
+    }
+
+    let downloaded = get_downloaded(&r);
+    let extracted = get_extracted(&r);
+    println!("\rComplete: {downloaded} B downloaded, {extracted} B extracted, {total_read} B read");
+    println!(
+        "{} messages retrieved ({messages} matches, {duplicates} duplicates)",
+        messages - duplicates,
+    );
+    Ok(())
+}
+
+/// Create a new mail directory structure, returning the `cur` path.
+fn create_maildir(dir: &Path) -> Result<PathBuf> {
+    let cur = dir.join("cur");
+    create_dir_if_not_exists(dir)?;
+    create_dir_if_not_exists(&dir.join("tmp"))?;
+    create_dir_if_not_exists(&dir.join("new"))?;
+    create_dir_if_not_exists(&cur)?;
+    Ok(cur)
+}
+
+/// Wrap the function in `util` with a specific error type.
+fn create_dir_if_not_exists(path: &Path) -> Result<()> {
+    util::create_dir_if_not_exists(path).map_err(|error| Error::CreateDirectory {
+        path: path.into(),
+        error,
+    })
+}
+
+/// Compute `git hash-object` output without calling `git`.
+fn git_hash_object(bytes: &[u8]) -> impl Display + 'static {
+    let mut m = sha1_smol::Sha1::new();
+    let pfx = format!("blob {}\0", bytes.len());
+    m.update(pfx.as_bytes());
+    m.update(bytes);
+    m.digest()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Cursor, Read},
+        process::{Command, Stdio},
+    };
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+    use tempdir::TempDir;
+
+    use super::*;
+
+    const MBOX: &str = indoc! {r#"
+        From mboxrd@z Thu Jan  1 00:00:00 1970
+        X-Some-Header: HeaderValue
+        From: Benno Lossin <b@l.org>
+        To: Trevor Gross <t@g.org>
+        Subject: Subject
+
+        Body1
+
+        From mboxrd@z Thu Jan  1 00:00:00 1970
+        From: Trevor Gross <t@g.org>
+        To: Benno Lossin <b@l.org>
+        Subject: Subject
+
+        Body2
+        This is mbox quoting, should turn into `From `:
+        > From hi
+
+        From mboxrd@z Thu Jan  1 00:00:00 1970
+        From: mail@email.org
+        To: List <list@mail.org>
+        Subject: Subject3
+
+        Body3
+    "#};
+
+    #[test]
+    fn basic_split() {
+        let dir = TempDir::new("test-mbox").unwrap();
+        let mut idx = 0;
+
+        mbox2mdir(
+            Cursor::new(MBOX),
+            dir.path(),
+            |_bytes| {
+                let name = format!("name{idx}");
+                idx += 1;
+                name
+            },
+            |_| 0,
+            |_| 0,
+        )
+        .unwrap();
+
+        for entry in fs::read_dir(dir.path()).unwrap() {
+            let entry = entry.unwrap();
+            let fname = entry.file_name();
+
+            let expected = if fname == "name0" {
+                indoc! {r#"
+                    X-Some-Header: HeaderValue
+                    From: Benno Lossin <b@l.org>
+                    To: Trevor Gross <t@g.org>
+                    Subject: Subject
+
+                    Body1
+                "#}
+            } else if fname == "name1" {
+                indoc! {r#"
+                    From: Trevor Gross <t@g.org>
+                    To: Benno Lossin <b@l.org>
+                    Subject: Subject
+
+                    Body2
+                    This is mbox quoting, should turn into `From `:
+                    From hi
+                "#}
+            } else if fname == "name2" {
+                indoc! {r#"
+                    From: mail@email.org
+                    To: List <list@mail.org>
+                    Subject: Subject3
+
+                    Body3
+                "#}
+            } else {
+                panic!("unexpected file {}", entry.path().display());
+            };
+
+            let contents = fs::read_to_string(entry.path()).unwrap();
+            assert_eq!(contents, expected, "file: {fname:?}");
+        }
+    }
+
+    #[test]
+    fn hash_object() {
+        fn hash_with_git(bytes: &[u8]) -> String {
+            let mut git = Command::new("git")
+                .args(["hash-object", "--stdin"])
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .unwrap();
+
+            let mut stdin = git.stdin.take().unwrap();
+            let mut stdout = git.stdout.take().unwrap();
+            stdin.write_all(bytes).unwrap();
+            drop(stdin);
+            let out = git.wait().unwrap();
+            assert!(out.success());
+
+            let mut s = String::new();
+            stdout.read_to_string(&mut s).unwrap();
+            s.trim().to_string()
+        }
+
+        let s = b"Hello, world!";
+        assert_eq!(git_hash_object(s).to_string(), hash_with_git(s));
+    }
+}

--- a/src/lei/leiless.rs
+++ b/src/lei/leiless.rs
@@ -125,6 +125,8 @@ fn mbox2mdir<R: BufRead>(
             .read_until(b'\n', &mut buf)
             .map_err(|error| Error::ReadInputStream { error })?;
         let line = &buf[..read_count];
+        let eof = read_count == 0;
+        let start_of_msg = line.starts_with(b"From ");
 
         let read_count_u64 = u64::try_from(read_count).unwrap();
         let new_total_read = total_read + read_count_u64;
@@ -143,14 +145,19 @@ fn mbox2mdir<R: BufRead>(
          * is implemented) */
 
         // Start of a new message or EOF
-        if line.starts_with(b"From ") || read_count == 0 {
+        if start_of_msg || eof {
             if !current_msg.is_empty() {
-                // Ensure a single trailing newline
-                current_msg.truncate(current_msg.trim_ascii_end().len());
-                current_msg.push(b'\n');
-                let trimmed = current_msg.trim_ascii_start();
+                // Due to the `read_until` call above, we should have a trailing `\n`.
+                // TODO: does mbox always have a trailing `\n` before EOF that we can strip? Our
+                // output for the last message does seem to match `lei`
+                assert_eq!(
+                    current_msg.pop(),
+                    Some(b'\n'),
+                    "possibly received broken mbox"
+                );
+                let to_write = &current_msg;
 
-                let fname = create_fname(trimmed);
+                let fname = create_fname(&to_write);
                 let fpath = dst.join(&fname);
 
                 // Write the file, failing if it exists
@@ -158,7 +165,7 @@ fn mbox2mdir<R: BufRead>(
                     .write(true)
                     .create_new(true)
                     .open(&fpath)
-                    .and_then(|mut f| f.write_all(trimmed))
+                    .and_then(|mut f| f.write_all(&to_write))
                     .or_else(|error| match error.kind() {
                         // lei deduplicates messages with the same hash automatically
                         io::ErrorKind::AlreadyExists => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,9 @@ mod assort;
 mod config;
 mod git;
 mod lei;
+mod util;
 
+type BoxStr = Box<str>;
 type BoxPath = Box<Path>;
 
 #[derive(Parser, Debug)]
@@ -68,7 +70,7 @@ fn run(interval: Interval, store: &Path, config: &Config) -> Result<ExitCode> {
             git::pull(store)?;
         }
     }
-    let new = lei::query(interval, &config.query)?;
+    let new = lei::query(interval, &config.query, config.no_lei)?;
     assort::run(new, Maildir::from(store.to_owned()), config)?;
     let mut did_commit = false;
     if config.git.is_some() && !git::is_clean(store)? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,8 @@ mod config;
 mod git;
 mod lei;
 
+type BoxPath = Box<Path>;
+
 #[derive(Parser, Debug)]
 struct Args {
     /// The amount of time to scan back

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,58 @@
+use std::{
+    fs,
+    io::{self, Read},
+    path::Path,
+};
+
+/// Add a total count to any reader.
+pub struct ReadCounter<R> {
+    reader: R,
+    count: u64,
+}
+
+impl<R> ReadCounter<R> {
+    pub fn new(reader: R) -> Self {
+        Self { reader, count: 0 }
+    }
+
+    pub fn get_ref(&self) -> &R {
+        &self.reader
+    }
+
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Helper to increment the count and return the input value.
+    fn increment_count(&mut self, add: usize) -> usize {
+        self.count += u64::try_from(add).unwrap();
+        add
+    }
+}
+
+impl<R: Read> Read for ReadCounter<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.reader.read(buf)?;
+        Ok(self.increment_count(n))
+    }
+
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        let n = self.reader.read_to_end(buf)?;
+        Ok(self.increment_count(n))
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.reader.read_exact(buf)?;
+        self.increment_count(buf.len());
+        Ok(())
+    }
+}
+
+/// Try to create a directory, ignore already exists errors.
+pub fn create_dir_if_not_exists(path: impl AsRef<Path>) -> io::Result<()> {
+    match fs::create_dir(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+        Err(e) => Err(e),
+    }
+}


### PR DESCRIPTION
`lei` isn't very cross-platform unfortunately, but its task isn't too
complicated. Add a fallback that can be used when `lei` isn't available
that downloads the messages from lore, extracts them, converts mbox to
maildir format, and names them based on their git hash. This seems to
match `lei`'s behavior.