### PR TITLE
drop prefix copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,5 +23,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Initial version.
 
 [unreleased]: https://github.com/y86-dev/lkml/compare/v0.1.1...HEAD
-[0.1.0]: https://github.com/y86-dev/lkml/releases/tag/v0.1.1
+[0.1.1]: https://github.com/y86-dev/lkml/releases/tag/v0.1.1
 [0.1.0]: https://github.com/y86-dev/lkml/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Drop new emails with the same ID as an existing one when the content of the new one is a prefix of
+  the existing one.
+
 ## [0.1.1] - 2025-05-28
 
 ### Fixed

--- a/src/assort/folder.rs
+++ b/src/assort/folder.rs
@@ -64,6 +64,7 @@ pub enum DropReason {
     DuplicateQuirk,
     VerbatimCopy,
     Ignored,
+    PrefixCopy,
 }
 
 impl Dest {

--- a/src/assort/mod.rs
+++ b/src/assort/mod.rs
@@ -171,6 +171,34 @@ fn index<'a>(
             {
                 trace!("dropping verbatim copy {}", mail.id);
                 actions.insert(mail.clone(), Action::delete(DropReason::VerbatimCopy));
+            } else if mails
+                .iter()
+                .filter(|m| m.id == mail.id)
+                .map(|m| {
+                    let m_content = m.parsed.get_body()?;
+                    let content = mail.parsed.get_body()?;
+                    if content.len() < m_content.len() {
+                        Ok(content == m_content[..content.len()])
+                    } else {
+                        if content[..m_content.len()] == m_content {
+                            error!(
+                                "new email received with same id as \
+                                existing & old email is a prefix of the new one\n\
+                                {:#?} vs\n{}\n\n {:#?}",
+                                mails.iter().map(|m| m.path.display()).collect::<Vec<_>>(),
+                                mail.path.display(),
+                                mail.parsed.headers.get_all_values("list-id")
+                            );
+                            error = true;
+                        }
+                        Ok(false)
+                    }
+                })
+                .reduce(|a: Result<bool, Error>, b| Ok(a? || b?))
+                .unwrap_or(Ok(false))?
+            {
+                trace!("dropping prefix-equivalent copy {}", mail.id);
+                actions.insert(mail.clone(), Action::delete(DropReason::PrefixCopy));
             } else {
                 error!(
                     "new email received with same id as existing, pls implement!\n{:#?} vs\n{}\n\n {:#?}",


### PR DESCRIPTION
* Drop new emails with the same ID as an existing one when the content of the new one is a prefix of
  the existing one.